### PR TITLE
Introducing command line capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Create a fresh Python 3.9 environment using venv, pyenv or conda (as preferred).
 
 For mac users, the following would be appropriate.
 
-```
+```sh
 brew install python@3.9
 python3.9 -m venv .venv
 source .venv/bin/activate
@@ -17,9 +17,31 @@ source .venv/bin/activate
 
 If running on M1 you will need to ensure the following library versions are being used. These should already be set in `requirements.txt`.
 
-```
+```sh
 pip install --upgrade torch==1.9.0
 pip install --upgrade torchvision==0.10.0
+```
+
+## Execution
+
+Once installed `bbb` can be run from the command line:
+
+```sh
+bbb [MODEL TYPE] [-d]
+```
+
+where the `-d` command is used to indicate whether to run the model deterministically (i.e., non-Bayesian approaches.).
+
+For example, to run classification using BBB use the command:
+
+```sh
+bbb class
+```
+
+Whereas, classification can be run deterministically using:
+
+```sh
+bbb class -d
 ```
 
 ## Citations

--- a/setup.py
+++ b/setup.py
@@ -27,4 +27,5 @@ setuptools.setup(
     packages=setuptools.find_packages(where="src"),
     python_requires=">=3.9",
     install_requires=required,
+    entry_points={'console_scripts':['bbb=bbb.cli:main']},
 )

--- a/src/bbb/cli.py
+++ b/src/bbb/cli.py
@@ -11,7 +11,7 @@ def init_argparse() -> argparse.ArgumentParser:
     :rtype: argparse.ArgumentParser
     """
     parser = argparse.ArgumentParser(
-        usage="%(prog)s [MODEL TYPE] [ARGS]...",
+        usage="%(prog)s [MODEL TYPE] [-d]...",
         description="Run the Bayes-by-Backprop code."
     )
     parser.add_argument(

--- a/src/bbb/cli.py
+++ b/src/bbb/cli.py
@@ -1,0 +1,54 @@
+import argparse
+from ctypes import ArgumentError
+
+from bbb.regression import run_dnn_regression
+from bbb.classify import run_bbb_mnist_classification, run_cnn_mnist_classification
+
+def init_argparse() -> argparse.ArgumentParser:
+    """Parse the command line arguments passed to the bbb module.
+
+    :return: Argument parser object
+    :rtype: argparse.ArgumentParser
+    """
+    parser = argparse.ArgumentParser(
+        usage="%(prog)s [MODEL TYPE] [ARGS]...",
+        description="Run the Bayes-by-Backprop code."
+    )
+    parser.add_argument(
+        "-v", "--version", action="version",
+        version = f"{parser.prog} version 1.0.0"
+    )
+    parser.add_argument(
+        'model_type', choices=['reg', 'class', 'rl'],
+        help='Model to run'
+    )
+    parser.add_argument(
+        '--deterministic',
+        '-d',
+        action='store_true',
+        help='Whether to run in deterministic (i.e., non-Bayesian) mode'
+    )
+    return parser
+
+def main() -> None:
+    """Parse the command line arguments passed and invoke the appropriate action.
+
+    :raises ArgumentError: Raised for argument combinations not yet implemented.
+    """
+    parser = init_argparse()
+    args = parser.parse_args()
+
+    if args.model_type == 'reg':
+        if args.deterministic:
+            run_dnn_regression()
+        else:
+            raise ArgumentError('Bayesian regression not yet implemented')
+    elif args.model_type == 'class':
+        if args.deterministic:
+            run_cnn_mnist_classification()
+        else:
+            run_bbb_mnist_classification()
+    elif args.model_type == 'rl':
+        raise ArgumentError('Reinforcement learning not yet implemented')
+    else:
+        raise ArgumentError(f'Model type {args.model_type} not recognised')

--- a/src/bbb/logging_setup.py
+++ b/src/bbb/logging_setup.py
@@ -7,4 +7,4 @@ logging.basicConfig(
     level=logging.DEBUG,
     # level=logging.INFO,
 )
-logging.getLogger('matplotlib.font_manager').disabled = True
+logging.getLogger('matplotlib').setLevel(logging.INFO)


### PR DESCRIPTION
Adding ability to run `bbb` from command line. For example, run deterministic (i.e. non-Bayesian) classification using

```sh
bbb class -d
```

Run `bbb --help` to see all arguments.