### PR TITLE
Fixing autograd issues

### DIFF
--- a/src/bbb/layers.py
+++ b/src/bbb/layers.py
@@ -24,14 +24,19 @@ class GaussianVarPost(nn.Module):
 
         self.mu = Parameter(mu_tensor)
         self.rho = Parameter(rho_tensor)
-        self.sigma = torch.log1p(1+torch.exp(self.rho)) # section 3.2: \sigma = log(1+exp(\rho))
-        self.dist = distributions.Normal(loc=self.mu, scale=self.sigma)
+
+    @property
+    def sigma(self):
+        return torch.log1p(1+torch.exp(self.rho)) # section 3.2: \sigma = log(1+exp(\rho))
 
     def sample(self):
-        return self.dist.sample().to(DEVICE)
+        epsilon = distributions.Normal(0,1).sample(self.rho.size()).to(DEVICE)
+        sample = self.mu + self.sigma * epsilon
+        return sample
 
     def log_prob(self, value):
-        return self.dist.log_prob(value)
+        log_prob = distributions.Normal(loc=self.mu, scale=self.sigma).log_prob(value)
+        return log_prob
 
 class BFC(nn.Module):
     """Bayesian (Weights) Fully Connected Layer"""

--- a/src/bbb/pytorch_setup.py
+++ b/src/bbb/pytorch_setup.py
@@ -12,3 +12,6 @@ else:
     logger.debug('CUDA unavailable - PyTorch will use CPU')
     dev = 'cpu'
 DEVICE = torch.device(dev)
+
+# Switch this on to find where issues are occurring
+# torch.autograd.set_detect_anomaly(True)


### PR DESCRIPTION
Squashed two bugs:

- Need to create a new `sigma` every time this is called, else pytorch tries to repeatedly calculate gradients. Setting `torch.autograd.set_detect_anomaly(True)` helped me find this one.
- Identified a related problem: the mu and sigma of the variational posterior are learnable, and so we want to take the gradient with respect to them. However, this: `distributions.Normal(loc=self.mu, scale=self.sigma).sample()` returns a new object unrelated to mu and sigma, and so prevents gradients being taken.