### PR TITLE
Adding ability to specify early stopping

### DIFF
--- a/src/bbb/config/parameters.py
+++ b/src/bbb/config/parameters.py
@@ -35,6 +35,11 @@ class Parameters:
     kl_reweighting_type: int = None       # method used for KL reweighting
     vp_variance_type: int = None          # type of variational posterior variance used
 
+    # Early stopping parameters
+    # By default, do not early stop
+    early_stopping: bool = False
+    early_stopping_thresh: float = 0
+
     # These parameters are unlikely to need to
     # be changed from their defaults
     model_save_dir: str = MODEL_SAVE_DIR

--- a/src/bbb/models/base.py
+++ b/src/bbb/models/base.py
@@ -30,6 +30,10 @@ class BaseModel(torch.nn.Module):
             os.makedirs(params.tensorboard_save_dir)
         self.writer = SummaryWriter(self.save_tensorboard_path)
 
+        # Early stopping criteria
+        self.early_stopping = params.early_stopping
+        self.early_stopping_thresh = params.early_stopping_thresh
+
     def load_saved(self):
         """Load a saved model.
 

--- a/src/bbb/tasks/regression.py
+++ b/src/bbb/tasks/regression.py
@@ -108,6 +108,8 @@ DNN_REGRESSION_PARAMETERS = Parameters(
     batch_size = 10,
     lr = 0.01,
     epochs = 100,
+    early_stopping=True,
+    early_stopping_thresh=1e-4
 )
 
 def run_dnn_regression_training():


### PR DESCRIPTION
Early stopping can now be specified in the model parameters. A threshold on the absolute difference between the loss of the previous run and the current is used as the basis.