### PR TITLE
Implementing Gaussian mixture prior for weights and biases

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,6 +35,7 @@ pytz==2021.3
 requests==2.27.1
 requests-oauthlib==1.3.1
 rsa==4.8
+setuptools==59.5.0
 six==1.16.0
 tensorboard==2.8.0
 tensorboard-data-server==0.6.1

--- a/src/bbb/config/constants.py
+++ b/src/bbb/config/constants.py
@@ -23,4 +23,15 @@ class _VariationalPosteriorVarianceTypes:
     """
     simple: int = 0
     paper: int = 1
-VP_VARIANCE_TYPES = _KlReweightingTypes()
+VP_VARIANCE_TYPES = _VariationalPosteriorVarianceTypes()
+
+@dataclass
+class _PriorTypes:
+    """Relates to section 3.3 of the paper which uses
+    a scale mixture prior.
+
+    The single option uses a singe Gaussian.
+    """
+    single: int = 0
+    mixture: int = 1
+PRIOR_TYPES = _PriorTypes()

--- a/src/bbb/config/parameters.py
+++ b/src/bbb/config/parameters.py
@@ -10,6 +10,10 @@ class PriorParameters:
     """
     w_sigma: Union[int, float]
     b_sigma: Union[int, float]
+    w_sigma_2: Union[int, float, None] = None
+    b_sigma_2: Union[int, float, None] = None
+    w_mixture_weight: Union[int, float, None] = None
+    b_mixture_weight: Union[int, float, None] = None
 
 @dataclass
 class Parameters:
@@ -34,6 +38,7 @@ class Parameters:
     inference_samples: int = None         # to draw for inference
     kl_reweighting_type: int = None       # method used for KL reweighting
     vp_variance_type: int = None          # type of variational posterior variance used
+    prior_type: int = None
 
     # Early stopping parameters
     # By default, do not early stop

--- a/src/bbb/models/bnn.py
+++ b/src/bbb/models/bnn.py
@@ -39,6 +39,7 @@ class BaseBNN(BaseModel, ABC):
         self.inference_samples = params.inference_samples
         self.batch_size = params.batch_size
         self.lr = params.lr
+        self.prior_type = params.prior_type
         self.kl_reweighting_type = params.kl_reweighting_type
         self.vp_variance_type = params.vp_variance_type
 
@@ -47,6 +48,7 @@ class BaseBNN(BaseModel, ABC):
             "weight_mu": self.weight_mu,
             "weight_rho": self.weight_rho,
             "prior_params": self.prior_params,
+            "prior_type": self.prior_type,
             "vp_var_type": self.vp_variance_type
         }
 

--- a/src/bbb/models/layers.py
+++ b/src/bbb/models/layers.py
@@ -1,10 +1,15 @@
+import logging
+
 import torch
 from torch import nn, distributions
 from torch.nn import Parameter
 
 from bbb.utils.pytorch_setup import DEVICE
-from bbb.config.constants import VP_VARIANCE_TYPES
+from bbb.config.constants import PRIOR_TYPES, VP_VARIANCE_TYPES
 from bbb.config.parameters import PriorParameters
+
+
+logger = logging.getLogger(__name__)
 
 class GaussianVarPost(nn.Module):
     def __init__(self, mu: float, rho: float, vp_var_type: int, dim_in: int = None, dim_out: int = None) -> None:
@@ -47,7 +52,16 @@ class GaussianVarPost(nn.Module):
 class BFC(nn.Module):
     """Bayesian (Weights) Fully Connected Layer"""
     
-    def __init__(self, dim_in: int, dim_out: int, weight_mu: float, weight_rho: float, prior_params: PriorParameters, vp_var_type: int):
+    def __init__(
+        self,
+        dim_in: int, 
+        dim_out: int,
+        weight_mu: float,
+        weight_rho: float,
+        prior_params: PriorParameters,
+        prior_type: int,
+        vp_var_type: int,
+    ):
         super().__init__()
         
         # Create IN X OUT weight tensor that we can sample from
@@ -55,10 +69,32 @@ class BFC(nn.Module):
         self.w_var_post = GaussianVarPost(weight_mu, weight_rho, dim_in=dim_in, dim_out=dim_out, vp_var_type=vp_var_type)
         self.b_var_post = GaussianVarPost(weight_mu, weight_rho, dim_out=dim_out, vp_var_type=vp_var_type)
 
-        # Set Prior distribution over the weights
-        assert prior_params.w_sigma and prior_params.b_sigma  # Assert that the required prior parameters are present
-        self.w_prior = distributions.Normal(0, prior_params.w_sigma)
-        self.b_prior = distributions.Normal(0, prior_params.b_sigma)
+        # Set Prior distribution over the weights and biases
+        assert prior_params.w_sigma and prior_params.b_sigma  # Assert that minimum required prior parameters are present
+        if prior_type == PRIOR_TYPES.single:
+            # Single Gaussian distribution
+            logger.info(f'Weights Prior: Gaussian with mean {0} and variance {prior_params.w_sigma}')
+            logger.info(f'Biases Prior: Gaussian with mean {0} and variance {prior_params.b_sigma}')
+
+            self.w_prior = distributions.Normal(0, prior_params.w_sigma)
+            self.b_prior = distributions.Normal(0, prior_params.b_sigma)
+        elif prior_type == PRIOR_TYPES.mixture:
+            # Mixture of Gaussian distributions
+            logger.info(f'Weights Prior: Gaussian mixture with means {(0,0)}, variances {(prior_params.w_sigma, prior_params.w_sigma_2)} and weight {prior_params.w_mixture_weight}')
+            logger.info(f'Biases Prior: Gaussian mixture with means {(0,0)}, variances {(prior_params.b_sigma, prior_params.b_sigma_2)} and weight {prior_params.b_mixture_weight}')
+
+            assert all((prior_params.w_sigma_2, prior_params.b_sigma_2, prior_params.w_mixture_weight, prior_params.b_mixture_weight))
+            
+            w_mix = distributions.Categorical(torch.tensor((prior_params.w_mixture_weight, 1-prior_params.w_mixture_weight)))
+            b_mix = distributions.Categorical(torch.tensor((prior_params.b_mixture_weight, 1-prior_params.b_mixture_weight)))
+
+            w_norm_comps = distributions.Normal(torch.zeros(2), torch.tensor((prior_params.w_sigma, prior_params.w_sigma_2), dtype=torch.float32))
+            b_norm_comps = distributions.Normal(torch.zeros(2), torch.tensor((prior_params.b_sigma, prior_params.b_sigma_2), dtype=torch.float32))
+
+            self.w_prior = distributions.MixtureSameFamily(w_mix, w_norm_comps)
+            self.b_prior = distributions.MixtureSameFamily(b_mix, b_norm_comps)
+        else:
+            raise RuntimeError(f'Unexpected prior type: {prior_type}')
 
         self.log_prior = 0
         self.log_var_post = 0

--- a/src/bbb/tasks/classification.py
+++ b/src/bbb/tasks/classification.py
@@ -2,7 +2,7 @@ import logging
 
 from bbb.utils.pytorch_setup import DEVICE
 from bbb.utils.tqdm import train_with_tqdm
-from bbb.config.constants import KL_REWEIGHTING_TYPES, VP_VARIANCE_TYPES
+from bbb.config.constants import KL_REWEIGHTING_TYPES, PRIOR_TYPES, VP_VARIANCE_TYPES
 from bbb.config.parameters import Parameters, PriorParameters
 from bbb.models.bnn import ClassificationBNN
 from bbb.models.cnn import CNN
@@ -33,6 +33,7 @@ BBB_CLASSIFY_PARAMETERS = Parameters(
     epochs = 300,
     elbo_samples = 2,
     inference_samples = 10,
+    prior_type=PRIOR_TYPES.single,
     kl_reweighting_type=KL_REWEIGHTING_TYPES.simple,
     vp_variance_type=VP_VARIANCE_TYPES.simple
 )

--- a/src/bbb/tasks/regression.py
+++ b/src/bbb/tasks/regression.py
@@ -8,7 +8,7 @@ from torch.utils.data import DataLoader
 
 from bbb.utils.pytorch_setup import DEVICE
 from bbb.utils.tqdm import train_with_tqdm
-from bbb.config.constants import KL_REWEIGHTING_TYPES, VP_VARIANCE_TYPES
+from bbb.config.constants import KL_REWEIGHTING_TYPES, PRIOR_TYPES, VP_VARIANCE_TYPES
 from bbb.config.parameters import Parameters, PriorParameters
 from bbb.models.dnn import DNN
 from bbb.models.bnn import RegressionBNN
@@ -50,8 +50,12 @@ BNN_REGRESSION_PARAMETERS = Parameters(
     weight_mu = [-0.2, 0.2],
     weight_rho = [-5, -4],
     prior_params = PriorParameters(
-        w_sigma=1,
-        b_sigma=2,
+        w_sigma=1.,
+        b_sigma=1.,
+        w_sigma_2=0.2,
+        b_sigma_2=0.2,
+        w_mixture_weight=0.5,
+        b_mixture_weight=0.5,
     ),
     hidden_units = 400,
     hidden_layers=3,
@@ -60,6 +64,7 @@ BNN_REGRESSION_PARAMETERS = Parameters(
     epochs = 100,
     elbo_samples = 5,
     inference_samples = 10,
+    prior_type=PRIOR_TYPES.mixture,
     kl_reweighting_type=KL_REWEIGHTING_TYPES.simple,
     vp_variance_type=VP_VARIANCE_TYPES.simple
 )


### PR DESCRIPTION
Aligned with section 3.3 of the paper, implemented the ability to specify a mixture of Gaussian prior over the weights and biases. The idea here is to make the weight concentrate around 0 a-priori. The prior resembles a spike and slab.