### PR TITLE
Updating vanilla CNN to use FC layers and plot weight dist

### DIFF
--- a/src/bbb/cli.py
+++ b/src/bbb/cli.py
@@ -6,7 +6,7 @@ from bbb.tasks.regression import (
     run_bbb_regression_training, run_bbb_regression_evaluation, run_dnn_regression_training, run_dnn_regression_evaluation
 )
 from bbb.tasks.classification import (
-    run_bbb_mnist_classification_training, run_bbb_mnist_classification_evaluation, run_cnn_mnist_classification_training
+    run_bbb_mnist_classification_training, run_bbb_mnist_classification_evaluation, run_cnn_mnist_classification_training, run_cnn_mnist_classification_evaluation
 )
 from bbb.tasks.bandit import run_rl_training
 
@@ -74,7 +74,7 @@ def main() -> None:
     elif args.model_type == 'class':
         if args.deterministic:
             if args.evaluate:
-                raise ArgumentError('Method not yet implemented')
+                run_cnn_mnist_classification_evaluation(args.evaluate)
             else:
                 run_cnn_mnist_classification_training()
         else:

--- a/src/bbb/models/bnn.py
+++ b/src/bbb/models/bnn.py
@@ -315,6 +315,9 @@ class BaseBNN(BaseModel, ABC):
         # Put model into evaluation mode
         self.eval()
 
+        ##################################
+        # Sampling weights and taking mean
+        ##################################
         # Initialise list of tensors to hold weight samples
         # Each tensor will hold samples of weights from a single layer
         weight_tensors = [
@@ -329,6 +332,16 @@ class BaseBNN(BaseModel, ABC):
         for i, layer in enumerate([l for l in self.model if isinstance(l, BFC)]):
             for j in range(self.inference_samples):
                 weight_tensors[i][:, j] = layer.w_var_post.sample().flatten()
+            
+             # Take the mean across the samples
+            weight_tensors[i] = weight_tensors[i].mean(axis=-1)
+
+        ####################
+        # Using mean weights
+        ####################
+        # weight_tensors = []
+        # for layer in [l for l in self.model if isinstance(l, BFC)]:
+        #     weight_tensors.append(layer.w_var_post.mu.flatten())
 
         return weight_tensors
 

--- a/src/bbb/tasks/classification.py
+++ b/src/bbb/tasks/classification.py
@@ -53,6 +53,9 @@ def run_bbb_mnist_classification_training():
 
     logger.info('Completed classification training...')
 
+    accuracy = net.evaluate(X_val)
+    logger.info(f'Accuracy: {accuracy}')
+
     weight_samples = net.weight_samples()
     plot_weight_samples(weight_samples, save_dir=net.model_save_dir)
 
@@ -75,6 +78,7 @@ CNN_CLASSIFY_PARAMETERS = Parameters(
     input_dim = 28*28,
     output_dim = 10,
     hidden_units = 1200,
+    hidden_layers = 2,
     batch_size = 128,
     lr = 0.01,
     epochs = 10,
@@ -84,10 +88,28 @@ def run_cnn_mnist_classification_training():
     logger.info('Beginning classification training...')
     net = CNN(params=CNN_CLASSIFY_PARAMETERS).to(DEVICE)
 
+    logger.info('Initialized CNN...')
+
     X_train = load_mnist(train=True, batch_size=CNN_CLASSIFY_PARAMETERS.batch_size, shuffle=True)
     X_val = load_mnist(train=False, batch_size=CNN_CLASSIFY_PARAMETERS.batch_size, shuffle=True)
 
+    logger.info('Loaded MNIST...')
+
     train_with_tqdm(net=net, train_data=X_train, epochs=CNN_CLASSIFY_PARAMETERS.epochs, eval_data=X_val)
 
-    accuracy = net.eval(X_val)
+    logger.info('Completed classification training...')
+
+    accuracy = net.evaluate(X_val)
     logger.info(f'Accuracy: {accuracy}')
+
+    weight_samples = net.weight_samples()
+    plot_weight_samples(weight_samples, save_dir=net.model_save_dir)
+
+def run_cnn_mnist_classification_evaluation(model_path: str):
+    logger.info(f'Beginning classification evaluation against {model_path}...')
+    
+    net = CNN(params=CNN_CLASSIFY_PARAMETERS, eval_mode=True).to(DEVICE)
+    net.load_saved(model_path=model_path)
+
+    weight_samples = net.weight_samples()
+    plot_weight_samples(weight_samples, save_dir=net.model_save_dir)

--- a/src/bbb/utils/plotting.py
+++ b/src/bbb/utils/plotting.py
@@ -75,7 +75,7 @@ def plot_weight_samples(
     """
     histogram_args = {
         'density': True,
-        'bins': 100,
+        'bins': 50,
         'alpha': 0.5
     }
 
@@ -85,7 +85,7 @@ def plot_weight_samples(
 
     fig, ax = plt.subplots(1, 1, figsize=(10,10))
     for i, weights in enumerate(weight_samples):
-            ax.hist(weights.flatten().detach().cpu().numpy(), label=f'Layer: {i}, Weights: {weights.shape[0]}', **histogram_args)
+            ax.hist(weights.detach().cpu().numpy(), label=f'Layer: {i}, Weights: {weights.shape[0]}', **histogram_args)
     
     # Formatting of plot
     ax.set_xlabel('Weight Value')
@@ -105,7 +105,7 @@ def plot_weight_samples(
     ################
 
     fig, ax = plt.subplots(1, 1, figsize=(10,10))
-    comb_weight_samples = torch.vstack(weight_samples)
+    comb_weight_samples = torch.hstack(weight_samples)
     ax.hist(comb_weight_samples.flatten().detach().cpu().numpy(), **histogram_args)
 
     # Formatting of plot


### PR DESCRIPTION
In the paper, the CNN uses FC layers, rather than convolutions. Potentially we should rename the class... Potentially could be merged with the FC class, although perhaps it's simpler to keep them separate.

Another change made is that an average of the BBB layer weights is taken across many inference samples. Could potentially just use the mu, but this was yielding odd results.