### PR TITLE
Adding step sizes for regression and classification

### DIFF
--- a/src/bbb/config/parameters.py
+++ b/src/bbb/config/parameters.py
@@ -25,7 +25,7 @@ class Parameters:
     output_dim: int
     batch_size: int
     lr: float
-    step_size: int
+    step_size: int          # Optimiser step size
     epochs: int
     hidden_layers: int = 1
 

--- a/src/bbb/models/bnn.py
+++ b/src/bbb/models/bnn.py
@@ -93,7 +93,8 @@ class BaseBNN(BaseModel, ABC):
 
         # Scheduler
         self.scheduler = optim.lr_scheduler.StepLR(
-            self.optimizer,step_size=self.step_size,
+            self.optimizer,
+            step_size=self.step_size,
             gamma=0.5
         )
 

--- a/src/bbb/tasks/classification.py
+++ b/src/bbb/tasks/classification.py
@@ -31,7 +31,7 @@ BBB_CLASSIFY_PARAMETERS = Parameters(
     batch_size = 128,
     lr = 1e-4,
     epochs = 300,
-    step_size = 100,
+    step_size = 75,
     elbo_samples = 2,
     inference_samples = 10,
     prior_type = PRIOR_TYPES.single,
@@ -83,7 +83,7 @@ DNN_CLASSIFY_PARAMETERS = Parameters(
     batch_size = 128,
     lr = 0.01,
     epochs = 300,
-    step_size = 100,
+    step_size = 75,
 )
 
 def run_dnn_mnist_classification_training():

--- a/src/bbb/tasks/classification.py
+++ b/src/bbb/tasks/classification.py
@@ -31,6 +31,7 @@ BBB_CLASSIFY_PARAMETERS = Parameters(
     batch_size = 128,
     lr = 1e-4,
     epochs = 300,
+    step_size = 100,
     elbo_samples = 2,
     inference_samples = 10,
     prior_type = PRIOR_TYPES.single,
@@ -81,7 +82,8 @@ DNN_CLASSIFY_PARAMETERS = Parameters(
     hidden_layers = 3,
     batch_size = 128,
     lr = 0.01,
-    epochs = 10,
+    epochs = 300,
+    step_size = 100,
 )
 
 def run_dnn_mnist_classification_training():

--- a/src/bbb/tasks/regression.py
+++ b/src/bbb/tasks/regression.py
@@ -71,6 +71,7 @@ BNN_REGRESSION_PARAMETERS = Parameters(
     batch_size = 128,
     lr = 1e-3,
     epochs = 1000,
+    step_size = 250,
     elbo_samples = 5,
     inference_samples = 10,
     prior_type = PRIOR_TYPES.single,
@@ -145,6 +146,7 @@ DNN_REGRESSION_PARAMETERS = Parameters(
     batch_size = 128,
     lr = 1e-3,
     epochs = 1000,
+    step_size = 250,
     early_stopping = False,
     early_stopping_thresh = 1e-4
 )


### PR DESCRIPTION
Setting the LR scheduler step size for regression and classification tasks. In both cases, the LR will be halved after every 1/4 of the epochs have been completed.